### PR TITLE
IncludeInterfaces property does not work if IncludeAbstract property does not enable

### DIFF
--- a/Enhanced.GetTypes.sln
+++ b/Enhanced.GetTypes.sln
@@ -10,6 +10,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "playground", "playground", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleLib", "playground\SampleLib\SampleLib.csproj", "{6688D6D1-9BEA-457A-921A-BE2874C2993F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{80F51C35-BAE8-4037-A29C-FE8A9466C937}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enhanced.GetTypes.Tests", "tests\Enhanced.GetTypes.Tests\Enhanced.GetTypes.Tests.csproj", "{FCC81115-783D-46D4-A5D8-0A25EED9A5F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,10 +32,15 @@ Global
 		{6688D6D1-9BEA-457A-921A-BE2874C2993F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6688D6D1-9BEA-457A-921A-BE2874C2993F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6688D6D1-9BEA-457A-921A-BE2874C2993F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCC81115-783D-46D4-A5D8-0A25EED9A5F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCC81115-783D-46D4-A5D8-0A25EED9A5F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCC81115-783D-46D4-A5D8-0A25EED9A5F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCC81115-783D-46D4-A5D8-0A25EED9A5F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B4845313-EA55-46AD-8346-5EC7BDBBD00F} = {B90371A4-96D6-4167-95C0-3F0995421BAA}
 		{80683002-DC2D-4E70-A213-37BB1F2D18C8} = {B90371A4-96D6-4167-95C0-3F0995421BAA}
 		{6688D6D1-9BEA-457A-921A-BE2874C2993F} = {572D9DE8-2C69-47D4-8C69-3E1BC7D5AD65}
+		{FCC81115-783D-46D4-A5D8-0A25EED9A5F6} = {80F51C35-BAE8-4037-A29C-FE8A9466C937}
 	EndGlobalSection
 EndGlobal

--- a/src/Enhanced.GetTypes.SourceGenerator/DerivedTypesLookupVisitor.cs
+++ b/src/Enhanced.GetTypes.SourceGenerator/DerivedTypesLookupVisitor.cs
@@ -42,7 +42,7 @@ internal class DerivedTypesLookupVisitor(DerivedTypesAttributeData attribute) : 
             return false;
         }
 
-        if (!attribute.IncludeAbstract && symbol.IsAbstract)
+        if (!attribute.IncludeAbstract && symbol is { IsAbstract: true, TypeKind: TypeKind.Class })
         {
             return false;
         }

--- a/tests/Enhanced.GetTypes.Tests/Enhanced.GetTypes.Tests.csproj
+++ b/tests/Enhanced.GetTypes.Tests/Enhanced.GetTypes.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+    <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+    <PackageReference Include="xunit" Version="2.5.3"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Enhanced.GetTypes.Annotation\Enhanced.GetTypes.Annotation.csproj"/>
+    <ProjectReference Include="..\..\src\Enhanced.GetTypes.SourceGenerator\Enhanced.GetTypes.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/Enhanced.GetTypes.Tests/GetTypesTests.cs
+++ b/tests/Enhanced.GetTypes.Tests/GetTypesTests.cs
@@ -1,0 +1,74 @@
+using Enhanced.GetTypes.Annotation;
+using FluentAssertions;
+
+namespace Enhanced.GetTypes.Tests;
+
+public class GetTypesTests
+{
+    [Fact]
+    public void ShouldReturnAllTypes()
+    {
+        var interfaces = TypesSource.GetAllTypes().ToArray();
+
+        interfaces.Should().Equal(
+            typeof(PublicDerivedClass),
+            typeof(InternalDerivedClass),
+            typeof(PublicAbstractDerivedClass),
+            typeof(InternalAbstractDerivedClass),
+            typeof(IPublicDerivedInterface),
+            typeof(IInternalDerivedInterface));
+    }
+
+    [Fact]
+    public void ShouldReturnTypesWithAbstract()
+    {
+        var interfaces = TypesSource.GetTypesWithAbstract().ToArray();
+
+        interfaces.Should().Equal(typeof(PublicDerivedClass), typeof(PublicAbstractDerivedClass));
+    }
+
+    [Fact]
+    public void ShouldReturnTypesWithInterfaces()
+    {
+        var interfaces = TypesSource.GetTypesWithInterfaces().ToArray();
+
+        interfaces.Should().Equal(typeof(PublicDerivedClass), typeof(IPublicDerivedInterface));
+    }
+
+    [Fact]
+    public void ShouldReturnTypesWithInternal()
+    {
+        var interfaces = TypesSource.GetTypesWithInternal().ToArray();
+
+        interfaces.Should().Equal(typeof(PublicDerivedClass), typeof(InternalDerivedClass));
+    }
+}
+
+public static partial class TypesSource
+{
+    [DerivedTypes(typeof(IInterface), IncludeInterfaces = true, IncludeInternal = true, IncludeAbstract = true)]
+    public static partial IEnumerable<Type> GetAllTypes();
+
+    [DerivedTypes(typeof(IInterface), IncludeAbstract = true)]
+    public static partial IEnumerable<Type> GetTypesWithAbstract();
+
+    [DerivedTypes(typeof(IInterface), IncludeInterfaces = true)]
+    public static partial IEnumerable<Type> GetTypesWithInterfaces();
+
+    [DerivedTypes(typeof(IInterface), IncludeInternal = true)]
+    public static partial IEnumerable<Type> GetTypesWithInternal();
+}
+
+public interface IInterface;
+
+public class PublicDerivedClass : IInterface;
+
+internal class InternalDerivedClass : IInterface;
+
+public abstract class PublicAbstractDerivedClass : IInterface;
+
+internal abstract class InternalAbstractDerivedClass : IInterface;
+
+public interface IPublicDerivedInterface : IInterface;
+
+internal interface IInternalDerivedInterface : IInterface;


### PR DESCRIPTION
Interfaces in .NET also relate to abstract types, so interfaces are ignored without `IncludeAbstract = true`. I fixed it by adding an additional condition `INamedTypeSymbol.TypeKind == TypeKind.Class`.